### PR TITLE
How `SHGetFolderPath()` retrieves the Windows Start menu folder path

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,7 @@ jobs:
       shell: cmd
       run: |
         reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v "Start Menu"
+      continue-on-error: true
 
     - name: Read Start menu folder path using SHGetFolderPath
       shell: cmd

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,5 +22,5 @@ jobs:
     - name: Test
       shell: cmd
       run: |
-        cl test.c
+        cl test.c /link Shell32.lib
         test.exe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,13 +15,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+    - name: Setup Developer Command Prompt
+      uses: ilammy/msvc-dev-cmd@v1
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '19.x'
 
     - name: Test
       shell: cmd
       run: |
-        where node
-        dir 'C:\Program Files (x86)\Windows Kits\10\bin'
+        cl test.c
+        test.exe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,32 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
     - uses: actions/checkout@v2
 
-    - name: Test
+    - name: Compile
       shell: cmd
       run: |
         cl test.c /link Shell32.lib
+
+    - name: Query registry
+      shell: cmd
+      run: |
+        reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v "Start Menu"
+
+    - name: Test
+      shell: cmd
+      run: |
+        test.exe
+
+    - name: Modify registry
+      shell: cmd
+      run: |
+        reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /t REG_SZ /v "Start Menu" /d "lol" /f
+
+    - name: Query registry
+      shell: cmd
+      run: |
+        reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v "Start Menu"
+
+    - name: Test
+      shell: cmd
+      run: |
         test.exe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,32 +19,47 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
     - uses: actions/checkout@v2
 
-    - name: Compile
+    - name: Compile program that uses SHGetFolderPath to read the Start menu folder path
       shell: cmd
       run: |
         cl test.c /link Shell32.lib
 
-    - name: Query registry
+    - name: Query Start menu folder path from registry
       shell: cmd
       run: |
         reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v "Start Menu"
 
-    - name: Test
+    - name: Read Start menu folder path using SHGetFolderPath
       shell: cmd
       run: |
         test.exe
 
-    - name: Modify registry
+    - name: Modify Start menu folder path to another existing folder path in registry
       shell: cmd
       run: |
-        reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /t REG_SZ /v "Start Menu" /d "lol" /f
+        reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /t REG_SZ /v "Start Menu" /d "C:\Users\runneradmin\AppData\Roaming\Microsoft\Windows" /f
 
-    - name: Query registry
+    - name: Query Start menu folder path from registry
       shell: cmd
       run: |
         reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v "Start Menu"
 
-    - name: Test
+    - name: Read Start menu folder path using SHGetFolderPath
+      shell: cmd
+      run: |
+        test.exe
+
+    - name: Modify Start menu folder path to inexistent folder path in registry
+      shell: cmd
+      run: |
+        reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /t REG_SZ /v "Start Menu" /d "lol" /f
+
+    - name: Query Start menu folder path from registry
+      shell: cmd
+      run: |
+        reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v "Start Menu"
+
+    - name: Read Start menu folder path using SHGetFolderPath
       shell: cmd
       run: |
         test.exe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,3 +63,18 @@ jobs:
       shell: cmd
       run: |
         test.exe
+
+    - name: Delete Start menu folder path from the registry
+      shell: cmd
+      run: |
+        reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /f /v "Start Menu"
+
+    - name: Query Start menu folder path from registry
+      shell: cmd
+      run: |
+        reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v "Start Menu"
+
+    - name: Read Start menu folder path using SHGetFolderPath
+      shell: cmd
+      run: |
+        test.exe

--- a/test.c
+++ b/test.c
@@ -1,4 +1,5 @@
 #include <Windows.h>
+#include <Shlobj.h>
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {

--- a/test.c
+++ b/test.c
@@ -1,26 +1,23 @@
-#include <direct.h>
-#include <errno.h>
+#include <Windows.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 int main(int argc, char *argv[]) {
-  if (_rmdir("a") == -1) {
-    fprintf(stderr,
-            "%s failed: errno(%d) = \"%s\", _doserrno = %d\n",
-            "_rmdir",
-            errno,
-            strerror(errno),
-            _doserrno);
-    exit(EXIT_FAILURE);
-  }
+  // Refs: https://referencesource.microsoft.com/#mscorlib/system/environment.cs,1506
+  char start_menu_folder_path[MAX_PATH];
+  int result = SHGetFolderPathA(
+      0,
+      CSIDL_STARTMENU,
+      0,
+      SHGFP_TYPE_CURRENT,
+      start_menu_folder_path);
 
-  fprintf(stdout,
-          "%s succeeded: errno(%d) = \"%s\", _doserrno = %d\n",
-          "_rmdir",
-          errno,
-          strerror(errno),
-          _doserrno);
+  if (result == S_OK) {
+    // Success case, so print the start menu folder path.
+    printf("Start menu folder path: \"%s\"\n", start_menu_folder_path);
+  } else {
+    // Error case, so print the error.
+    printf("Error code: %d\n", result);
+  }
 
   return 0;
 }


### PR DESCRIPTION
In this experiment, I tried understanding how [`SHGetFolderPath()`](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetfolderpatha) retrieves the `Start menu` folder path.

`test.c` is a simple program that just prints the result of calling `SHGetFolderPath()` to get the `Start menu` folder path:
https://github.com/RaisinTen/tests/blob/69c51beb0486c4412f156608d3df2b0b4aeedf60/test.c#L1-L24
It prints the retrieved path on success and prints the error code on failure.

The workflow compares how modifications to the `Start Menu` key under `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders` in the Windows registry affects the results of the program:
https://github.com/RaisinTen/tests/blob/e47a1d8b9a3667cf7876cf2411b958c82852afc9/.github/workflows/CI.yml#L27-L81

In case we lose the GitHub Actions run results in https://github.com/RaisinTen/tests/actions/runs/12392536916/job/34591919938 in the future, here are the results:
```
> Query Start menu folder path from registry
HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders
    Start Menu    REG_EXPAND_SZ    %USERPROFILE%\AppData\Roaming\Microsoft\Windows\Start Menu
> Read Start menu folder path using SHGetFolderPath
Start menu folder path: "C:\Users\runneradmin\AppData\Roaming\Microsoft\Windows\Start Menu"
> Modify Start menu folder path to another existing folder path in registry
The operation completed successfully.
> Query Start menu folder path from registry
HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders
    Start Menu    REG_SZ    C:\Users\runneradmin\AppData\Roaming\Microsoft\Windows
> Read Start menu folder path using SHGetFolderPath
Start menu folder path: "C:\Users\runneradmin\AppData\Roaming\Microsoft\Windows"
> Modify Start menu folder path to inexistent folder path in registry
The operation completed successfully.
> Query Start menu folder path from registry
HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders
    Start Menu    REG_SZ    lol
> Read Start menu folder path using SHGetFolderPath
Error code: -2147024894
> Delete Start menu folder path from the registry
The operation completed successfully.
> Query Start menu folder path from registry
ERROR: The system was unable to find the specified registry key or value.
Error: Process completed with exit code 1.
> Read Start menu folder path using SHGetFolderPath
Start menu folder path: "C:\Users\runneradmin\AppData\Roaming\Microsoft\Windows\Start Menu"
```

So this is my understanding of how `SHGetFolderPath()` works:
1. `SHGetFolderPath()` tries to access the `Start Menu` key from `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders` in the Windows registry
2. Check if the registry key is not found:
  i. If not found, return `"%USERPROFILE%\AppData\Roaming\Microsoft\Windows\Start Menu"` (with `%USERPROFILE%` filled in).
  ii. If found, check if the path exists:
    a. If it does not exist, return `-2147024894` error, which means `ERROR_FILE_NOT_FOUND` (see https://learn.microsoft.com/en-us/answers/questions/1621377/what-causes-the-error-2147024894-error-file-not-fo).
    b. If it exists, return that path